### PR TITLE
updated badges after transfer to RBVI ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![CircleCI](https://img.shields.io/circleci/build/github/jewettaij/minrms/main)](https://circleci.com/gh/jewettaij/minrms)
+[![CircleCI](https://img.shields.io/circleci/build/github/RBVI/minrms/main)](https://circleci.com/gh/RBVI/minrms)
 [![C++11](https://img.shields.io/badge/C%2B%2B-11-blue.svg)](https://isocpp.org/std/the-standard)
-[![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/jewettaij/minrms)]()
+[![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/RBVI/minrms)]()
 [![Website](https://img.shields.io/website?down_color=orange&down_message=moltemplate.org%20offline&up_color=green&up_message=online&url=https%3A%2F%2Fwww.cgl.ucsf.edu%2FResearch%2Fminrms)](http://www.cgl.ucsf.edu/Research/minrms)
 
 


### PR DESCRIPTION
Currently the *minrms* repository uses circleci.com to handle CI/CD automated testing.  When users visit the old minrms code, the README.md file would display a bright green sign which indicates to all visitors that the code compiles and works:

![example passing badge](https://camo.githubusercontent.com/ad5e4f7787b7b5c53efe0e5cee88c5bebad5a21d34949a25455ec3b39254573a/68747470733a2f2f7472617669732d63692e636f6d2f6a657765747461696a2f6a61636f62695f70642e7376673f6272616e63683d6d6173746572)

Unfortunately, now after transferring the project to RBVI, the links have been broken and there is a bright red mark where the green badge used to be.  To fix it, we need to do two things:

1) Update the links in the README.md file so that they refer to "RBVI/minrms" instead of "jewettaij/minrms".  This pull-request takes care of this issue.
2) Obtain permission from RBVI to allow circleci.com to access repository information and run automated tests on the RBVI repositories.  Once we allow circleci.com to access our repositories, *then* we can select which repositories we want CircleCI to access.  I was only planning to enable CircleCI to access the *minrms* repository. *(Note: This does not commit you to use CircleCI for everything.  You could use CircleCI for MINRMS, and some other service like travis-ci.com or jenkins.io for CHIMERAX, for example.  CircleCI is free for small projects with less than ~20 commits per day, which is perfect for minrms.)*  But   either way, I highly recommend taking advantage of these free testing services.  They have improved the quality of my own code.  We can have a discussion about this if you like.